### PR TITLE
Add umd build to support usage through unpkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "source": "src/tinykeys.ts",
   "main": "dist/tinykeys.js",
   "module": "dist/tinykeys.module.js",
+  "unpkg": "dist/tinykeys.umd.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
I have been playing with this package in an environment where I cannot npm install it.

To solve that, I added a `umd` build that is handled by `microbundle` so that this can be served through `unpkg`