### PR TITLE
Added missing target in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import tinykeys from "tinykeys"
 
 function useKeyboardShortcuts() {
   useEffect(() => {
-    let unsubscribe = tinykeys({
+    let unsubscribe = tinykeys(window, {
       // ...
     })
     return () => {


### PR DESCRIPTION
One of the examples was missing target, went directly to object. Was confused why my copied code wasn't working 😅 