### PR TITLE
Short circuit on explicit result

### DIFF
--- a/src/tinykeys.ts
+++ b/src/tinykeys.ts
@@ -117,7 +117,7 @@ export default function keybindings(
 			return
 		}
 
-		keyBindings.forEach(keyBinding => {
+		keyBindings.some(keyBinding => {
 			let sequence = keyBinding[0]
 			let callback = keyBinding[1]
 
@@ -134,6 +134,7 @@ export default function keybindings(
 			} else {
 				possibleMatches.delete(sequence)
 				callback(event)
+				return true
 			}
 		})
 


### PR DESCRIPTION
At the moment tinykeys keeps iterating over the rest of the keybindings even when a match was found - even though only one keybinding is supported per combination.