### PR TITLE
Fix invalid events from being passed to handler

### DIFF
--- a/src/tinykeys.ts
+++ b/src/tinykeys.ts
@@ -108,6 +108,13 @@ export default function keybindings(
 	let timer: any = null
 
 	let onKeyDown = (event: KeyboardEvent) => {
+		// Ensure and stop any event that isn't a full keyboard event.
+		// Autocomplete option navigation and selection would fire a instanceof Event,
+		// instead of the expected KeyboardEvent
+		if (!(event instanceof KeyboardEvent)) {
+			return
+		}
+
 		// Ignore modifier keydown events
 		// Note: This works because:
 		// - non-modifiers will always return false


### PR DESCRIPTION
When selecting a suggested autocomplete option with arrow keys and selecting with Tab / Enter the `keyDown` event handler was receiving a raw `Event`. I simply added a check to ensure we have the proper event types before continuing.


### Previous Bug Reproduction:
- Add a `<input>` with an `autocomplete`
- Select an autocomplete option with arrow keys and try to select with `Enter` or `Tab`
- Observe that a error will pop in console `Uncaught TypeError: event.getModifierState is not a function`, event is actually an `instanceof` `Event` instead of expected `KeyboardEvent`