### PR TITLE
Check if getModifierState exists before calling it

### DIFF
--- a/src/tinykeys.ts
+++ b/src/tinykeys.ts
@@ -30,6 +30,16 @@ let MOD =
 		: "Control"
 
 /**
+ * There's a bug in Chrome that causes event.getModifierState not to exist on
+ * KeyboardEvent's for F1/F2/etc keys.
+ */
+function getModifierState(event: KeyboardEvent, mod: string) {
+	return typeof event.getModifierState === "function"
+		? event.getModifierState(mod)
+		: false
+}
+
+/**
  * Parses a "Key Binding String" into its parts
  *
  * grammar    = `<sequence>`
@@ -66,14 +76,14 @@ function match(event: KeyboardEvent, press: KeyBindingPress): boolean {
 
 		// Ensure all the modifiers in the keybinding are pressed.
 		press[0].find(mod => {
-			return !event.getModifierState(mod)
+			return !getModifierState(event, mod)
 		}) ||
 
 		// KEYBINDING_MODIFIER_KEYS (Shift/Control/etc) change the meaning of a
 		// keybinding. So if they are pressed but aren't part of the current
 		// keybinding press, then we don't have a match.
 		KEYBINDING_MODIFIER_KEYS.find(mod => {
-			return !press[0].includes(mod) && press[1] !== mod && event.getModifierState(mod)
+			return !press[0].includes(mod) && press[1] !== mod && getModifierState(event, mod)
 		})
 	)
 }
@@ -135,7 +145,7 @@ export default function keybindings(
 				// - non-modifiers will always return false
 				// - if the current keypress is a modifier then it will return true when we check its state
 				// MDN: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState
-				if (!event.getModifierState(event.key)) {
+				if (!getModifierState(event, event.key)) {
 					possibleMatches.delete(sequence)
 				}
 			} else if (remainingExpectedPresses.length > 1) {


### PR DESCRIPTION
Fixes #40 

Reproduction: https://codesandbox.io/s/jamiebuildstinykeys40-4q2lu

I still need to test this out on Windows.