### PR TITLE
rename parse method to parseKeybinding, export & document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,25 @@ Each press can optionally be prefixed with modifier keys:
 
 Each press in the sequence must be pressed within 1000ms of the last.
 
+### Display the keyboard sequence
+
+You can use the `parseKeybinding` method to get a structured representation of a keyboard shortcut. It can be useful when you want to display it in a fancier way than a plain string.
+
+```js
+import { parseKeybinding } from "tinykeys"
+
+let parsedShortcut = parseKeybinding('$mod+Shift+K $mod+1');
+```
+
+Results into:
+
+```js
+[
+  [["Meta", "Shift"], "K"],
+  [["Meta"], "1"],
+]
+```
+
 ## Additional Configuration Options
 
 You can configure the behavior of tinykeys in a couple ways using a third

--- a/src/tinykeys.ts
+++ b/src/tinykeys.ts
@@ -82,7 +82,7 @@ function getModifierState(event: KeyboardEvent, mod: string) {
  * <press>    = `<key>` or `<mods>+<key>`
  * <mods>     = `<mod>+<mod>+...`
  */
-function parse(str: string): KeyBindingPress[] {
+export function parseKeybinding(str: string): KeyBindingPress[] {
 	return str
 		.trim()
 		.split(" ")
@@ -152,7 +152,7 @@ export function createKeybindingsHandler(
 	let timeout = options.timeout ?? DEFAULT_TIMEOUT
 
 	let keyBindings = Object.keys(keyBindingMap).map(key => {
-		return [parse(key), keyBindingMap[key]] as const
+		return [parseKeybinding(key), keyBindingMap[key]] as const
 	})
 
 	let possibleMatches = new Map<KeyBindingPress[], KeyBindingPress[]>()


### PR DESCRIPTION
## Description

* This PR is to address the feature request raised in #142 
* The parse method has been renamed to `parseKeybinding`
* The `parseKeybinding` method is exported so consumers can import it.
* The `parseKeybinding` has some basic docs to show its usage and output.