### PR TITLE
Use only named export

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,4 +1,4 @@
-import tinykeys from "../src/tinykeys"
+import { tinykeys } from "../src/tinykeys"
 
 tinykeys(window, {
 	"Shift+D": () => {

--- a/src/tinykeys.ts
+++ b/src/tinykeys.ts
@@ -199,9 +199,9 @@ export function createKeybindingsHandler(
  *
  * @example
  * ```js
- * import keybindings from "../src/keybindings"
+ * import { tinykeys } from "../src/tinykeys"
  *
- * keybindings(window, {
+ * tinykeys(window, {
  * 	"Shift+d": () => {
  * 		alert("The 'Shift' and 'd' keys were pressed at the same time")
  * 	},
@@ -214,7 +214,7 @@ export function createKeybindingsHandler(
  * })
  * ```
  */
-function keybindings(
+export function tinykeys(
 	target: Window | HTMLElement,
 	keyBindingMap: KeyBindingMap,
 	options: KeyBindingOptions = {},
@@ -228,5 +228,3 @@ function keybindings(
 		target.removeEventListener(event, onKeyEvent)
 	}
 }
-
-export { keybindings as tinykeys }

--- a/src/tinykeys.ts
+++ b/src/tinykeys.ts
@@ -214,7 +214,7 @@ export function createKeybindingsHandler(
  * })
  * ```
  */
-export default function keybindings(
+function keybindings(
 	target: Window | HTMLElement,
 	keyBindingMap: KeyBindingMap,
 	options: KeyBindingOptions = {},
@@ -228,3 +228,5 @@ export default function keybindings(
 		target.removeEventListener(event, onKeyEvent)
 	}
 }
+
+export { keybindings as tinykeys }


### PR DESCRIPTION
resolve #138 

rollup.js, on which Microbundle depends, is bad practice to mix default and named exports in same module.
https://rollupjs.org/guide/en/#default-export

So I changed it to use only named exports.