### PR TITLE
fix: exports types field

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "exports": {
     ".": {
       "import": "./dist/tinykeys.module.js",
-      "require": "./dist/tinykeys.js"
+      "require": "./dist/tinykeys.js",
+      "types": "./dist/tinykeys.d.ts"
     }
   },
   "keywords": [


### PR DESCRIPTION
it reports the following error on one of my repo

```
Could not find a declaration file for module 'tinykeys'. '.../node_modules/tinykeys/dist/tinykeys.module.js' implicitly has an 'any' type.
  There are types at '.../node_modules/tinykeys/dist/tinykeys.d.ts', but this result could not be resolved when respecting package.json "exports". The 'tinykeys' library may need to update its package.json or typings.
```

The PR fixes the above issue.