### PR TITLE
Add "types" to package.json exports spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/tinykeys.d.ts",
       "import": "./dist/tinykeys.module.js",
       "require": "./dist/tinykeys.js"
     }


### PR DESCRIPTION
Fixes https://github.com/jamiebuilds/tinykeys/issues/191
Closes #188
Closes #192 

Enables compatibility with various TypeScript module resolution modes: https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports

Technically, you can avoid specifying `"types"` in an `"exports"` spec because [TypeScript will attempt file extension substitution](https://www.typescriptlang.org/docs/handbook/modules/reference.html#file-extension-substitution). However, in resolution modes that prefer the `"import"` condition, it will attempt to substitute the extension using the basename `tinykeys.module` and will not find anything.

The easiest fix is to specify `"types"` and avoid the substitution path.
