### PR TITLE
Proper handling of (Key/Digit) in KeyboardEvent.code regex

### DIFF
--- a/src/tinykeys.ts
+++ b/src/tinykeys.ts
@@ -127,7 +127,7 @@ export function matchKeyBindingPress(
 		// MDN event.key: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
 		// MDN event.code: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code
 		(
-			key instanceof RegExp ? !(key.test(event.key) || key.test(event.code)) :
+			key instanceof RegExp ? !(key.test(event.key) || key.test(event.code.replace(/^(Key|Digit)/, ''))) :
 			(key.toUpperCase() !== event.key.toUpperCase() &&
 			key !== event.code)
 		) ||


### PR DESCRIPTION
@jamiebuilds This PR handles regex matches with KeyboardEvent.code

example:
in case of KeyBindingPress = [['Shift'], /^[0-9]$/]
when pressing Shift+2, KeyboardEvent.key = '@' and KeyboardEvent.code = 'Digit2'