### PR TITLE
Add compatability layer for keybinding splitting regex

### DIFF
--- a/src/tinykeys.ts
+++ b/src/tinykeys.ts
@@ -155,6 +155,27 @@ function getModifierState(event: KeyboardEvent, mod: string) {
 		: false
 }
 
+function splitKeybindingPress(press: string): string[] {
+	try {
+		return press.split(new RegExp("(?<=\\w|\\])\\+"))
+	} catch {
+		return splitKeybindingPressFallback(press)
+	}
+}
+
+function splitKeybindingPressFallback(press: string): string[] {
+	let parts: string[] = []
+	let start = 0
+	for (let index = 0; index < press.length; index++) {
+		if (press[index] === "+" && /[\w\]]/.test(press[index - 1] ?? "")) {
+			parts.push(press.slice(start, index))
+			start = index + 1
+		}
+	}
+	parts.push(press.slice(start))
+	return parts
+}
+
 /**
  * Parses a keybinding string into its parts.
  *
@@ -165,7 +186,7 @@ function getModifierState(event: KeyboardEvent, mod: string) {
  * <mods>     = `<mod>+<mod>+...`
  * <mod>      = `<modifier>` (required) or `[<modifier>]` (optional)
  * <key>      = `<KeyboardEvent.key>` or `<KeyboardEvent.code>` (case-insensitive)
- * <key>      = `(<regex>)` -> `/^(?:<regex>)$/iy` (case-insensitive)
+ * <key>      = `(<regex>)` -> `/^(?:<regex>)$/iv` (case-insensitive)
  * ```
  */
 export function parseKeybinding(str: string): KeybindingPress[] {
@@ -173,7 +194,7 @@ export function parseKeybinding(str: string): KeybindingPress[] {
 		.trim()
 		.split(" ")
 		.map(press => {
-			let parts = press.split(/(?<=\w|\])\+/)
+			let parts = splitKeybindingPress(press)
 
 			let last: string | RegExp = parts.pop() as string
 			let regex = last.match(/^\((.+)\)$/)

--- a/test/tinykeys.test.ts
+++ b/test/tinykeys.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi, onTestFinished } from "vitest"
 import { userEvent } from "vitest/browser"
 import {
+	parseKeybinding,
 	tinykeys,
 	type KeybindingsMap,
 	type KeybindingOptions,
@@ -34,6 +35,36 @@ function compositionEvent(type: string, init?: CompositionEventInit) {
 }
 
 test.describe("tinykeys()", () => {
+	test.describe("parseKeybinding()", () => {
+		test("splits optional modifiers with regex lookbehind", () => {
+			expect(parseKeybinding("Control+[Shift]+a")).toEqual([
+				[["Control"], ["Shift"], "a"],
+			])
+		})
+
+		test("falls back when regex lookbehind is unsupported", () => {
+			let NativeRegExp = RegExp
+
+			class IosRegExp extends NativeRegExp {
+				constructor(pattern: string, flags?: string) {
+					if (pattern.includes("(?<=")) {
+						throw new SyntaxError("Invalid regular expression")
+					}
+					super(pattern, flags)
+				}
+			}
+
+			vi.stubGlobal("RegExp", IosRegExp)
+			onTestFinished(() => {
+				vi.unstubAllGlobals()
+			})
+
+			expect(parseKeybinding("Control+[Shift]+a")).toEqual([
+				[["Control"], ["Shift"], "a"],
+			])
+		})
+	})
+
 	test.describe("single press", () => {
 		test("KeyboardEvent.key", async () => {
 			let cb = vi.fn()


### PR DESCRIPTION
Fixes keybinding parsing on older iOS versions by falling back only when the lookbehind regex used to split keybinding parts is unsupported.

Added parser tests covering both the normal lookbehind split and the fallback path.