### PR TITLE
Explicitly check that event.target is an HTMLElement

### DIFF
--- a/src/tinykeys.ts
+++ b/src/tinykeys.ts
@@ -131,16 +131,16 @@ function isKeyboardEvent(
  * are the current target.
  */
 export function defaultKeybindingsHandlerIgnore(event: KeyboardEvent) {
-	let target = event.target as HTMLElement
 	return (
 		// Always ignore repeated keyboard events
 		event.repeat ||
 		// Always ignore keyboard events during composition input
 		event.isComposing ||
 		// Always allow the current target
-		(target !== event.currentTarget &&
+		(event.target !== event.currentTarget &&
+			event.target instanceof HTMLElement &&
 			// Ignore contenteditable and form elements
-			target.matches("[contenteditable],input,select,textarea"))
+			event.target.matches("[contenteditable],input,select,textarea"))
 	)
 }
 


### PR DESCRIPTION
Tinykeys currently crashes when dispatching synthetic keyboard events to non-HTMLElement EventTargets, such as `document`. ([Issue in the Home Assistant app](https://github.com/home-assistant/android/issues/6952), [Code in the Home Assistant app](https://github.com/home-assistant/android/blob/d21e938ca1795d88b50a554f32a2f4604342c609/app/src/main/kotlin/io/homeassistant/companion/android/frontend/gesture/FrontendGestureManager.kt#L118-L127))